### PR TITLE
[bbc_stock][ADD] added no_create options and some fields invisible

### DIFF
--- a/bbc_stock/README.rst
+++ b/bbc_stock/README.rst
@@ -35,6 +35,8 @@ Other functionality
 * Hide the stock locations group on the product form
 * Hide the lot tracking group on the product form
 * #2660, don't allow consumables with more than one attribute to be selected on a manually created stock move
+* Disable create and edit function for the fields under the website group on the product form
+* Hide style and sequence fields under the website group on the product form
 
 Credits
 -------

--- a/bbc_stock/__openerp__.py
+++ b/bbc_stock/__openerp__.py
@@ -31,6 +31,7 @@
         'delivery',
         'bbc_sale',
         'mob_tracking',
+        'website_sale_options',
     ],
     'data': [
         'views/assets.xml',

--- a/bbc_stock/views/product.xml
+++ b/bbc_stock/views/product.xml
@@ -34,9 +34,9 @@
             </field>
         </record>
 
-        <record id="website_sale_product_template_form_view_inherited" model="ir.ui.view">
-            <field name="name">Disable create and edit option for some fields</field>
-            <field name="inherit_id" ref="website_sale.product_template_form_view" />
+        <record id="website_sale_options_product_template_form_view_inherited" model="ir.ui.view">
+            <field name="name">Change options and visibility for some fields</field>
+            <field name="inherit_id" ref="website_sale_options.product_template_form_view" />
             <field name="model">product.template</field>
             <field name="priority" eval="15" />
             <field name="arch" type="xml">
@@ -49,6 +49,9 @@
                 <field name="accessory_product_ids" position="attributes">
                     <attribute name="options">{'no_create': True}</attribute>
                 </field>
+                <field name="optional_product_ids" position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                </field>
                 <field name="website_style_ids" position="attributes">
                     <attribute name="invisible">1</attribute>
                 </field>
@@ -57,18 +60,6 @@
                 </field>
             </field>
         </record>
-
-        <record id="website_sale_options_product_template_form_view_inherited" model="ir.ui.view">
-            <field name="name">Disable create and edit option for a field</field>
-            <field name="inherit_id" ref="website_sale_options.product_template_form_view" />
-            <field name="model">product.template</field>
-            <field name="priority" eval="15" />
-            <field name="arch" type="xml">
-                <field name="optional_product_ids" position="attributes">
-                    <attribute name="options">{'no_create': True}</attribute>
-                </field>
-            </field>
-        </record>
-
+        
     </data>
 </openerp>

--- a/bbc_stock/views/product.xml
+++ b/bbc_stock/views/product.xml
@@ -34,5 +34,41 @@
             </field>
         </record>
 
+        <record id="website_sale_product_template_form_view_inherited" model="ir.ui.view">
+            <field name="name">Disable create and edit option for some fields</field>
+            <field name="inherit_id" ref="website_sale.product_template_form_view" />
+            <field name="model">product.template</field>
+            <field name="priority" eval="15" />
+            <field name="arch" type="xml">
+                <field name="public_categ_ids" position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                </field>
+                <field name="alternative_product_ids" position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                </field>
+                <field name="accessory_product_ids" position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                </field>
+                <field name="website_style_ids" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="website_sequence" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="website_sale_options_product_template_form_view_inherited" model="ir.ui.view">
+            <field name="name">Disable create and edit option for a field</field>
+            <field name="inherit_id" ref="website_sale_options.product_template_form_view" />
+            <field name="model">product.template</field>
+            <field name="priority" eval="15" />
+            <field name="arch" type="xml">
+                <field name="optional_product_ids" position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
For the following fields on product.template I added a no_create option (because we do want to create records within these models on this place):

- public_categ_ids
- alternative_product_ids
- accessory_product_ids
- optional_product_ids

The following fields on product.template are invisible now (because unused):

- website_style_ids
- website_sequence