### PR TITLE
[bbc_sale][ADD] Introduce house_number and house_number_addition to partner form

### DIFF
--- a/bbc_sale/README.rst
+++ b/bbc_sale/README.rst
@@ -1,4 +1,4 @@
-Sale customizations for Babycare
+﻿Sale customizations for Babycare
 ================================
 
 * When a payment is registered for a sales order that is in state 'Shipping exception', the outgoing delivery is recreated
@@ -43,3 +43,4 @@ a negative expected stock level (or are in an exception state, as red is the def
 * Introduce variant_published flag on the variant level (cf. template's website_published flag)
 * Introduce variant_eol flag on the variant level (cf. template's eol/obsolete states)
 * variant_published and variant_eol are kept in sync with nonconfigurable templates
+* Introduce house_number and house_number_addition to partner form

--- a/bbc_sale/i18n_extra/nl.po
+++ b/bbc_sale/i18n_extra/nl.po
@@ -25,3 +25,27 @@ msgstr "Opmerkingen"
 msgid "Can be ordered"
 msgstr "Bestelbaar"
 
+#. module: bbc_sale
+#: view:res.partner:bbc_sale.view_partner_form_inherit_house_number_and_addition
+msgid "Add."
+msgstr "Toev."
+
+#. module: bbc_sale
+#: field:res.partner,house_number:0
+msgid "House number"
+msgstr "Huisnummer"
+
+#. module: bbc_sale
+#: field:res.partner,house_number_addition:0
+msgid "House number addition"
+msgstr "Huisnummertoevoeging"
+
+#. module: bbc_sale
+#: view:res.partner:bbc_sale.view_partner_form_inherit_house_number_and_addition
+msgid "Nr."
+msgstr "Nr."
+
+#. module: bbc_sale
+#: view:res.partner:bbc_sale.view_partner_form_inherit_house_number_and_addition
+msgid "Street extra"
+msgstr "Straat toev."

--- a/bbc_sale/models/res_partner.py
+++ b/bbc_sale/models/res_partner.py
@@ -15,6 +15,8 @@ class Partner(models.Model):
         'Supplier delay',
         help='Default supplier delay when this supplier is linked to a product'
     )
+    house_number = fields.Char('House number')
+    house_number_addition = fields.Char('House number addition')
 
     @api.multi
     def _pos_order_count(self):
@@ -28,3 +30,65 @@ class Partner(models.Model):
         res = super(Partner, self)._commercial_fields()
         res.append('amount_free_shipping')
         return res
+
+    @api.multi
+    def name_get(self):
+        res = []
+        for partner in self:
+            name = partner.name or ''
+            if partner.parent_id and not \
+                    partner.is_company and partner.parent_id.is_company:
+                    name = "%s, %s" % (partner.parent_id.name, name)
+            if self._context.get('show_address_only'):
+                name = partner._display_address(without_company=True)
+            if self._context.get('show_address'):
+                name = name + "\n" + partner._display_address(
+                    without_company=True)
+                name = name.replace('\n\n', '\n')
+                name = name.replace('\n\n', '\n')
+            if self._context.get('show_email') and partner.email:
+                name = "%s <%s>" % (name, partner.email)
+            if self._context.get('html_format'):
+                name = name.replace('\n', '<br/>')
+            res.append((partner.id, name))
+        return res
+
+    @api.multi
+    def _display_address(self, without_company=False):
+        """
+        Return an address formatted according to the country standards.
+
+        :param address: browse record of the res.partner to format
+        :returns: the address formatted in a display that fit its country
+            habits (or the default ones if not country is specified)
+        :rtype: string
+        """
+        # get the information that will be injected into the display format
+        # get the address format
+        if self.country_id.address_format:
+            address_format = self.country_id.address_format.replace(
+                '%(street)s',
+                '%(street)s %(house_number)s %(house_number_addition)s')
+            address_format = "%(wk_company)s\n" + address_format
+        else:
+            address_format = "%(wk_company)s\n%(street)s %(house_number)s \
+                %(house_number_addition)s\n%(street2)s\n%(city)s \
+                %(state_code)s %(zip)s\n%(country_name)s"
+        args = {
+            'wk_company': self.wk_company or '',
+            'house_number': self.house_number or '',
+            'house_number_addition': self.house_number_addition or '',
+            'state_code': self.state_id.code or '',
+            'state_name': self.state_id.name or '',
+            'country_code': self.country_id.code or '',
+            'country_name': self.country_id.name or '',
+            'company_name': self.parent_id.is_company and
+            self.parent_id.name or '',
+        }
+        for field in self._address_fields():
+            args[field] = getattr(self, field) or ''
+        if without_company:
+            args['company_name'] = ''
+        elif self.parent_id:
+            address_format = '%(company_name)s\n' + address_format
+        return address_format % args

--- a/bbc_sale/views/res_partner.xml
+++ b/bbc_sale/views/res_partner.xml
@@ -37,5 +37,38 @@
             </field>
         </record>
 
+        <record id="view_partner_form_inherit_house_number_and_addition" model="ir.ui.view">
+            <field name="name">Add house number and house number addition to partner form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="priority">40</field>
+            <field name="arch" type="xml">
+                <field name="street" position="attributes">
+                    <attribute name="style">width: 80%</attribute>
+                </field>
+                <field name="street" position="after">
+                    <field name="house_number" style="width: 10%" placeholder="Nr." />
+                    <field name="house_number_addition" style="width: 10%" placeholder="Add." />
+                </field>
+                <field name="street2" position="attributes">
+                    <attribute name="placeholder">Street extra</attribute>
+                </field>
+                
+                <xpath expr="//sheet/notebook/page[@string='Contacts']/field[@name='child_ids']/form/sheet/group/div[@name='div_address']/field[@name='street']" position="attributes">
+                    <attribute name="style">width: 80%</attribute>
+                </xpath>
+                
+                <xpath expr="//sheet/notebook/page[@string='Contacts']/field[@name='child_ids']/form/sheet/group/div[@name='div_address']/field[@name='street']" position="after">
+                    <field name="house_number" style="width: 10%" placeholder="Nr." />
+                    <field name="house_number_addition" style="width: 10%" placeholder="Add." />
+                </xpath>
+                
+                <xpath expr="//sheet/notebook/page[@string='Contacts']/field[@name='child_ids']/form/sheet/group/div[@name='div_address']/field[@name='street2']" position="attributes">
+                    <attribute name="placeholder">Street extra</attribute>
+                </xpath>
+
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
New fields house_number and house_number_addition on partner form. In the nearby future we will export our outgoing deliveries to our shipper software. This software requires a separate field for the house number and the house number addition.

- The house number and house number addition fields are added on the partner form behind the street field; the width of the street field is changed to 80%.
- The house number and house number addition fields are added to the contact persons form (first tab on the partner form) behind the street field; the width of the street field is changed to 80%.
- Field translations has been added.
- Functions name_get and _display_address in res_partner.py are rewritten to include the house_number and house_number_addition on the sale order form. [Note: a rewrite of the function name_get was necessary because the previous rewritten function of Webkul could not be used anymore.]

**Roadmap**

- Include house number and house number addition fields on leads form and prospects form.