### PR TITLE
[ADD][bbc_sale] don't allow consumables with one attribute to be selected on an account invoice line/mrp bom line

### DIFF
--- a/bbc_sale/README.rst
+++ b/bbc_sale/README.rst
@@ -44,3 +44,5 @@ a negative expected stock level (or are in an exception state, as red is the def
 * Introduce variant_eol flag on the variant level (cf. template's eol/obsolete states)
 * variant_published and variant_eol are kept in sync with nonconfigurable templates
 * Introduce is_synced_magento flag on product to search on synced to Magento products
+* Don't allow consumables with one attribute to be selected on an account invoice line
+* Don't allow consumables with one attribute to be selected on a mrp bom line

--- a/bbc_sale/models/__init__.py
+++ b/bbc_sale/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_invoice
+from . import account_invoice_line
 from . import mail_thread
 from . import mrp_bom
 from . import mrp_bom_line

--- a/bbc_sale/models/account_invoice_line.py
+++ b/bbc_sale/models/account_invoice_line.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from openerp import models, fields
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = 'account.invoice.line'
+
+    product_id = fields.Many2one(
+        domain=[('sale_ok', '=', True), ('consu_single_attr', '=', False)])

--- a/bbc_sale/models/mrp_bom_line.py
+++ b/bbc_sale/models/mrp_bom_line.py
@@ -1,9 +1,12 @@
 # coding: utf-8
-from openerp import api, models
+from openerp import models, fields, api
 
 
 class MrpBomLine(models.Model):
     _inherit = 'mrp.bom.line'
+
+    product_id = fields.Many2one(
+        domain=[('sale_ok', '=', True), ('consu_single_attr', '=', False)])
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
Add domains (('sale_ok', '=', True), ('consu_single_attr', '=', False)) to product_id fields in account.invoice.line and mrp.bom.line.
These domains are needed because otherwise a variant of a config product can be selected on the account invoice line and the mrp bom line. We want to avoid this.