### PR TITLE
[bbc_stock][ADD] Filter on is_synced_magento == True for the fields under the website group on the product form

### DIFF
--- a/bbc_stock/README.rst
+++ b/bbc_stock/README.rst
@@ -35,7 +35,7 @@ Other functionality
 * Hide the stock locations group on the product form
 * Hide the lot tracking group on the product form
 * #2660, don't allow consumables with more than one attribute to be selected on a manually created stock move
-* Disable create and edit function for the fields under the website group on the product form
+* Disable create and edit function and filter on is_synced_magento == True for the fields under the website group on the product form
 * Hide style and sequence fields under the website group on the product form
 
 Credits

--- a/bbc_stock/views/product.xml
+++ b/bbc_stock/views/product.xml
@@ -45,12 +45,15 @@
                 </field>
                 <field name="alternative_product_ids" position="attributes">
                     <attribute name="options">{'no_create': True}</attribute>
+                    <attribute name="domain">"[('is_synced_magento', '=', True)]"</attribute>
                 </field>
                 <field name="accessory_product_ids" position="attributes">
                     <attribute name="options">{'no_create': True}</attribute>
+                    <attribute name="domain">"[('is_synced_magento', '=', True)]"</attribute>
                 </field>
                 <field name="optional_product_ids" position="attributes">
                     <attribute name="options">{'no_create': True}</attribute>
+                    <attribute name="domain">"[('is_synced_magento', '=', True)]"</attribute>
                 </field>
                 <field name="website_style_ids" position="attributes">
                     <attribute name="invisible">1</attribute>


### PR DESCRIPTION
Added domain [('is_synced_magento', '=', True)] to the following fields under the website group of the product form: alternative_product_ids, accessory_product_ids and optional_product_ids.

Exporting/updating a product form to Magento with not-synced alternative, accessory or optional products will give an error. To avoid this kind of mistakes only already synced products can be selected in these fields.