### PR TITLE
[ADD][bbc_sale] The volume and weight field on the product form are invisible

### DIFF
--- a/bbc_sale/README.rst
+++ b/bbc_sale/README.rst
@@ -46,3 +46,4 @@ Sale customizations for Babycare
 * Don't allow consumables with one attribute to be selected on an account invoice line
 * Don't allow consumables with one attribute to be selected on a mrp bom line
 * The warranty field on the product form is made invisible
+* The volume and weight field on the product form are invisible

--- a/bbc_sale/views/product.xml
+++ b/bbc_sale/views/product.xml
@@ -128,6 +128,12 @@
                 <xpath expr="//group[@name='sale_condition']/label[@for='warranty']" position="attributes">
                     <attribute name="invisible">1</attribute>
                 </xpath>
+                <xpath expr="//group[@name='weight']/field[@name='volume']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//group[@name='weight']/field[@name='weight']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
The volume and weight field on the product form are invisible; we only use the weight_net field.