### PR TITLE
[babycare_product_brand][IMP] make strings in product.py unique because otherwise there are duplicates in the advanced search

### DIFF
--- a/babycare_product_brand/__openerp__.py
+++ b/babycare_product_brand/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Product Attribute Manager',
-    'version': '8.0.1.0',
+    'version': '8.0.1.1',
     'category': 'Product',
     'summary': 'Add attributes to products',
     'author':

--- a/babycare_product_brand/i18n/nl.po
+++ b/babycare_product_brand/i18n/nl.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-08 14:23+0000\n"
-"PO-Revision-Date: 2017-09-08 14:23+0000\n"
+"POT-Creation-Date: 2017-11-02 14:49+0000\n"
+"PO-Revision-Date: 2017-11-02 14:49+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,8 +18,8 @@ msgstr ""
 #. module: babycare_product_brand
 #: field:product.product,product_monitors_includingrecallfunction:0
 #: field:product.template,product_monitors_includingrecallfunction:0
-msgid "2-way voice operation"
-msgstr "Terugspreekfunctie"
+msgid "2-way voice operation (Monitors)"
+msgstr "Terugspreekfunctie (Babyfoons)"
 
 #. module: babycare_product_brand
 #: model:ir.actions.act_window,help:babycare_product_brand.action_product_attributemanager_product_brand
@@ -31,7 +31,7 @@ msgid "<p class=\"oe_view_nocontent_create\">\n"
 "                </p>\n"
 "            "
 msgstr "<p class=\"oe_view_nocontent_create\">\n"
-"                    Klik om een nieuw merk te definiëren.\n"\n"
+"                    Klik om een nieuw merk te definiëren.\n"
 "                </p>\n"
 "                <p>\n"
 "                    Je moet een merk definiëren voordat je het merk kunt toevoegen aan een product.\n"
@@ -58,22 +58,38 @@ msgstr "<p class=\"oe_view_nocontent_create\">\n"
 #. module: babycare_product_brand
 #: field:product.product,product_buggies_adjustablebackrest:0
 #: field:product.template,product_buggies_adjustablebackrest:0
-msgid "Adjustable Backrest?"
-msgstr "Verstelbare rugleuning?"
+msgid "Adjustable Backrest? (Buggies)"
+msgstr "Verstelbare rugleuning? (Buggys)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_buggies_agecategory_id:0
-#: field:product.product,product_carseats_agecategory_id:0
-#: field:product.product,product_highchairs_agecategory_id:0
-#: field:product.product,product_toys_agecategory_id:0
-#: field:product.template,product_buggies_agecategory_id:0
-#: field:product.template,product_carseats_agecategory_id:0
-#: field:product.template,product_highchairs_agecategory_id:0
-#: field:product.template,product_toys_agecategory_id:0
 msgid "Age Category"
 msgstr "Leeftijdscategorie"
+
+#. module: babycare_product_brand
+#: field:product.product,product_buggies_agecategory_id:0
+#: field:product.template,product_buggies_agecategory_id:0
+msgid "Age Category (Buggies)"
+msgstr "Leeftijdscategorie (Buggys)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carseats_agecategory_id:0
+#: field:product.template,product_carseats_agecategory_id:0
+msgid "Age Category (Car Seats)"
+msgstr "Leeftijdscategorie (Autostoelen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_highchairs_agecategory_id:0
+#: field:product.template,product_highchairs_agecategory_id:0
+msgid "Age Category (High Chairs)"
+msgstr "Leeftijdscategorie (Kinderstoelen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_toys_agecategory_id:0
+#: field:product.template,product_toys_agecategory_id:0
+msgid "Age Category (Toys)"
+msgstr "Leeftijdscategorie (Speelgoed)"
 
 #. module: babycare_product_brand
 #: model:ir.ui.menu,name:babycare_product_brand.product_attribute_manager
@@ -123,18 +139,26 @@ msgstr "Draagsystemen"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_carseats_childlength_id:0
-#: field:product.template,product_carseats_childlength_id:0
 msgid "Child Length"
 msgstr "Lengte Kind"
 
 #. module: babycare_product_brand
+#: field:product.product,product_carseats_childlength_id:0
+#: field:product.template,product_carseats_childlength_id:0
+msgid "Child Length (Car Seats)"
+msgstr "Lengte Kind (Autostoelen)"
+
+#. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_carseats_childweight_id:0
-#: field:product.template,product_carseats_childweight_id:0
 msgid "Child Weight"
 msgstr "Gewicht Kind"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carseats_childweight_id:0
+#: field:product.template,product_carseats_childweight_id:0
+msgid "Child Weight (Car Seats)"
+msgstr "Gewicht Kind (Autostoelen)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
@@ -144,13 +168,21 @@ msgstr "Kleding"
 
 #. module: babycare_product_brand
 #: field:product.product,product_highchairs_collapsible:0
-#: field:product.product,product_rockers_collapsible:0
-#: field:product.product,product_travelcots_collapsible:0
 #: field:product.template,product_highchairs_collapsible:0
+msgid "Collapsible (High Chairs)"
+msgstr "Inklapbaar (Kinderstoelen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_rockers_collapsible:0
 #: field:product.template,product_rockers_collapsible:0
+msgid "Collapsible (Rockers)"
+msgstr "Inklapbaar (Wipstoelen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_travelcots_collapsible:0
 #: field:product.template,product_travelcots_collapsible:0
-msgid "Collapsible"
-msgstr "Inklapbaar"
+msgid "Collapsible (Travelcots)"
+msgstr "Inklapbaar (Campingbedden)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
@@ -196,12 +228,20 @@ msgstr "Standaard"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_carriers_directionofuse_id:0
-#: field:product.product,product_carseats_directionofuse_id:0
-#: field:product.template,product_carriers_directionofuse_id:0
-#: field:product.template,product_carseats_directionofuse_id:0
 msgid "Direction of Use"
 msgstr "Gebruiksrichting"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carseats_directionofuse_id:0
+#: field:product.template,product_carseats_directionofuse_id:0
+msgid "Direction of Use (Car Seats)"
+msgstr "Gebruiksrichting (Autostoelen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carriers_directionofuse_id:0
+#: field:product.template,product_carriers_directionofuse_id:0
+msgid "Direction of Use (Carriers)"
+msgstr "Gebruiksrichting (Draagsystemen)"
 
 #. module: babycare_product_brand
 #: field:custom.option,display_name:0
@@ -212,8 +252,8 @@ msgstr "Weergavenaam"
 #. module: babycare_product_brand
 #: field:product.product,product_clothes_gender:0
 #: field:product.template,product_clothes_gender:0
-msgid "Gender"
-msgstr "Geslacht"
+msgid "Gender (Clothes)"
+msgstr "Geslacht (Kleding)"
 
 #. module: babycare_product_brand
 #: selection:product.template,product_clothes_gender:0
@@ -240,34 +280,38 @@ msgstr "ID"
 #. module: babycare_product_brand
 #: field:product.product,product_monitors_includingcamera:0
 #: field:product.template,product_monitors_includingcamera:0
-msgid "Including Camera"
-msgstr "Inclusief camera"
+msgid "Including Camera (Monitors)"
+msgstr "Inclusief camera (Babyfoons)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_travelcots_includingcreephatch:0
 #: field:product.template,product_travelcots_includingcreephatch:0
-msgid "Including Creep Hatch"
-msgstr "Inclusief kruipluik"
+msgid "Including Creep Hatch (Travelcots)"
+msgstr "Inclusief kruipluik (Campingbedden)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_highchairs_includingdinnertray:0
 #: field:product.template,product_highchairs_includingdinnertray:0
-msgid "Including Dinner Tray"
-msgstr "Inclusief eetblad"
+msgid "Including Dinner Tray (High Chairs)"
+msgstr "Inclusief eetblad (Kinderstoelen)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_travelcots_includingwheels:0
 #: field:product.template,product_travelcots_includingwheels:0
-msgid "Including Wheels"
-msgstr "Inclusief wielen"
+msgid "Including Wheels (Travelcots)"
+msgstr "Inclusief wielen (Campingbedden)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_carseats_installmethod_id:0
-#: field:product.template,product_carseats_installmethod_id:0
 msgid "Install Method"
 msgstr "Installatiemethode"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carseats_installmethod_id:0
+#: field:product.template,product_carseats_installmethod_id:0
+msgid "Install Method (Car Seats)"
+msgstr "Installatiemethode (Autostoelen)"
 
 #. module: babycare_product_brand
 #: field:custom.option,__last_update:0
@@ -295,30 +339,50 @@ msgstr "Magento Option Id"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_highchairs_material_id:0
-#: field:product.template,product_highchairs_material_id:0
 msgid "Material"
 msgstr "Materiaal"
 
 #. module: babycare_product_brand
-#: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
-#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_buggies_maxcarryweight_id:0
-#: field:product.product,product_carriers_maxcarryweight_id:0
-#: field:product.product,product_rockers_maxcarryweight_id:0
-#: field:product.template,product_buggies_maxcarryweight_id:0
-#: field:product.template,product_carriers_maxcarryweight_id:0
-#: field:product.template,product_rockers_maxcarryweight_id:0
-msgid "Maximum Carry Weight"
-msgstr "Maximaal draaggewicht"
+#: field:product.product,product_highchairs_material_id:0
+#: field:product.template,product_highchairs_material_id:0
+msgid "Material (High Chairs)"
+msgstr "Materiaal (Kinderstoelen)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_monitors_maxrange_id:0
-#: field:product.template,product_monitors_maxrange_id:0
+msgid "Maximum Carry Weight"
+msgstr "Maximaal draaggewicht"
+
+#. module: babycare_product_brand
+#: field:product.product,product_buggies_maxcarryweight_id:0
+#: field:product.template,product_buggies_maxcarryweight_id:0
+msgid "Maximum Carry Weight (Buggies)"
+msgstr "Maximaal draaggewicht (Buggys)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carriers_maxcarryweight_id:0
+#: field:product.template,product_carriers_maxcarryweight_id:0
+msgid "Maximum Carry Weight (Carriers)"
+msgstr "Maximaal draaggewicht (Draagsystemen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_rockers_maxcarryweight_id:0
+#: field:product.template,product_rockers_maxcarryweight_id:0
+msgid "Maximum Carry Weight (Rockers)"
+msgstr "Maximaal draaggewicht (Wipstoelen)"
+
+#. module: babycare_product_brand
+#: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
 msgid "Maximum Range"
 msgstr "Maximaal bereik"
+
+#. module: babycare_product_brand
+#: field:product.product,product_monitors_maxrange_id:0
+#: field:product.template,product_monitors_maxrange_id:0
+msgid "Maximum Range (Monitors)"
+msgstr "Maximaal bereik (Babyfoons)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
@@ -352,12 +416,20 @@ msgstr "Niet gesynchroniseerd"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_buggies_numberofwheels_id:0
-#: field:product.product,product_strollers_numberofwheels_id:0
-#: field:product.template,product_buggies_numberofwheels_id:0
-#: field:product.template,product_strollers_numberofwheels_id:0
 msgid "Number of Wheels"
 msgstr "Aantal wielen"
+
+#. module: babycare_product_brand
+#: field:product.product,product_buggies_numberofwheels_id:0
+#: field:product.template,product_buggies_numberofwheels_id:0
+msgid "Number of Wheels (Buggies)"
+msgstr "Aantal wielen (Buggys)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_strollers_numberofwheels_id:0
+#: field:product.template,product_strollers_numberofwheels_id:0
+msgid "Number of Wheels (Strollers)"
+msgstr "Aantal wielen (Kinderwagens)"
 
 #. module: babycare_product_brand
 #: view:custom.option:babycare_product_brand.view_customoption_filter
@@ -377,7 +449,7 @@ msgstr "Product"
 #. module: babycare_product_brand
 #: model:ir.actions.act_window,name:babycare_product_brand.product_attributemanager_synchronize_action
 msgid "Product Attribute Manager"
-msgstr "Product Attribuut Manager"
+msgstr "Product Attribute Manager"
 
 #. module: babycare_product_brand
 #: model:ir.model,name:babycare_product_brand.model_product_template
@@ -393,20 +465,32 @@ msgstr "Wipstoelen"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_clothes_season_id:0
-#: field:product.template,product_clothes_season_id:0
 msgid "Season"
 msgstr "Seizoen"
 
 #. module: babycare_product_brand
+#: field:product.product,product_clothes_season_id:0
+#: field:product.template,product_clothes_season_id:0
+msgid "Season (Clothes)"
+msgstr "Seizoen (Kleding)"
+
+#. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_clothes_size_id:0
-#: field:product.product,product_textiles_size_id:0
-#: field:product.template,product_clothes_size_id:0
-#: field:product.template,product_textiles_size_id:0
 msgid "Size"
 msgstr "Maat"
+
+#. module: babycare_product_brand
+#: field:product.product,product_clothes_size_id:0
+#: field:product.template,product_clothes_size_id:0
+msgid "Size (Clothes)"
+msgstr "Maat (Kleding)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_textiles_size_id:0
+#: field:product.template,product_textiles_size_id:0
+msgid "Size (Textiles)"
+msgstr "Maat (Textiel)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
@@ -465,12 +549,20 @@ msgstr "Campingbedden"
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
 #: view:product.product:babycare_product_brand.product_product_form_attribute_manager
-#: field:product.product,product_carriers_type_id:0
-#: field:product.product,product_toys_type_id:0
-#: field:product.template,product_carriers_type_id:0
-#: field:product.template,product_toys_type_id:0
 msgid "Type"
 msgstr "Soort"
+
+#. module: babycare_product_brand
+#: field:product.product,product_carriers_type_id:0
+#: field:product.template,product_carriers_type_id:0
+msgid "Type (Carriers)"
+msgstr "Soort (Draagsystemen)"
+
+#. module: babycare_product_brand
+#: field:product.product,product_toys_type_id:0
+#: field:product.template,product_toys_type_id:0
+msgid "Type (Toys)"
+msgstr "Soort (Speelgoed)"
 
 #. module: babycare_product_brand
 #: selection:product.template,product_clothes_gender:0

--- a/babycare_product_brand/i18n/nl.po
+++ b/babycare_product_brand/i18n/nl.po
@@ -59,7 +59,7 @@ msgstr "<p class=\"oe_view_nocontent_create\">\n"
 #: field:product.product,product_buggies_adjustablebackrest:0
 #: field:product.template,product_buggies_adjustablebackrest:0
 msgid "Adjustable Backrest? (Buggies)"
-msgstr "Verstelbare rugleuning? (Buggys)"
+msgstr "Verstelbare rugleuning? (Buggy's)"
 
 #. module: babycare_product_brand
 #: view:product.attributemanager:babycare_product_brand.view_product_attributemanager_form
@@ -71,7 +71,7 @@ msgstr "Leeftijdscategorie"
 #: field:product.product,product_buggies_agecategory_id:0
 #: field:product.template,product_buggies_agecategory_id:0
 msgid "Age Category (Buggies)"
-msgstr "Leeftijdscategorie (Buggys)"
+msgstr "Leeftijdscategorie (Buggy's)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_carseats_agecategory_id:0
@@ -358,7 +358,7 @@ msgstr "Maximaal draaggewicht"
 #: field:product.product,product_buggies_maxcarryweight_id:0
 #: field:product.template,product_buggies_maxcarryweight_id:0
 msgid "Maximum Carry Weight (Buggies)"
-msgstr "Maximaal draaggewicht (Buggys)"
+msgstr "Maximaal draaggewicht (Buggy's)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_carriers_maxcarryweight_id:0
@@ -423,7 +423,7 @@ msgstr "Aantal wielen"
 #: field:product.product,product_buggies_numberofwheels_id:0
 #: field:product.template,product_buggies_numberofwheels_id:0
 msgid "Number of Wheels (Buggies)"
-msgstr "Aantal wielen (Buggys)"
+msgstr "Aantal wielen (Buggy's)"
 
 #. module: babycare_product_brand
 #: field:product.product,product_strollers_numberofwheels_id:0

--- a/babycare_product_brand/i18n/nl.po
+++ b/babycare_product_brand/i18n/nl.po
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-02 14:49+0000\n"
-"PO-Revision-Date: 2017-11-02 14:49+0000\n"
+"POT-Creation-Date: 2017-11-13 08:49+0000\n"
+"PO-Revision-Date: 2017-11-13 08:49+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "2-way voice operation"
+msgstr "Terugspreekfunctie"
 
 #. module: babycare_product_brand
 #: field:product.product,product_monitors_includingrecallfunction:0
@@ -54,6 +59,11 @@ msgstr "<p class=\"oe_view_nocontent_create\">\n"
 "                    Je moet een record definiëren voordat je het record kunt toevoegen aan een product.\n"
 "                </p>\n"
 "            "
+
+#. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Adjustable Backrest"
+msgstr "Verstelbare rugleuning"
 
 #. module: babycare_product_brand
 #: field:product.product,product_buggies_adjustablebackrest:0
@@ -167,6 +177,11 @@ msgid "Clothes"
 msgstr "Kleding"
 
 #. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Collapsible"
+msgstr "Inklapbaar"
+
+#. module: babycare_product_brand
 #: field:product.product,product_highchairs_collapsible:0
 #: field:product.template,product_highchairs_collapsible:0
 msgid "Collapsible (High Chairs)"
@@ -250,6 +265,11 @@ msgid "Display Name"
 msgstr "Weergavenaam"
 
 #. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Gender"
+msgstr "Geslacht"
+
+#. module: babycare_product_brand
 #: field:product.product,product_clothes_gender:0
 #: field:product.template,product_clothes_gender:0
 msgid "Gender (Clothes)"
@@ -278,10 +298,20 @@ msgid "ID"
 msgstr "ID"
 
 #. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Including Camera"
+msgstr "Inclusief camera"
+
+#. module: babycare_product_brand
 #: field:product.product,product_monitors_includingcamera:0
 #: field:product.template,product_monitors_includingcamera:0
 msgid "Including Camera (Monitors)"
 msgstr "Inclusief camera (Babyfoons)"
+
+#. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Including Creep Hatch"
+msgstr "Inclusief kruipluik"
 
 #. module: babycare_product_brand
 #: field:product.product,product_travelcots_includingcreephatch:0
@@ -290,10 +320,20 @@ msgid "Including Creep Hatch (Travelcots)"
 msgstr "Inclusief kruipluik (Campingbedden)"
 
 #. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Including Dinner Tray"
+msgstr "Inclusief eetblad"
+
+#. module: babycare_product_brand
 #: field:product.product,product_highchairs_includingdinnertray:0
 #: field:product.template,product_highchairs_includingdinnertray:0
 msgid "Including Dinner Tray (High Chairs)"
 msgstr "Inclusief eetblad (Kinderstoelen)"
+
+#. module: babycare_product_brand
+#: view:product.product:babycare_product_brand.product_product_form_attribute_manager
+msgid "Including Wheels"
+msgstr "Inclusief wielen"
 
 #. module: babycare_product_brand
 #: field:product.product,product_travelcots_includingwheels:0

--- a/babycare_product_brand/migrations/8.0.1.1/pre-migrate.py
+++ b/babycare_product_brand/migrations/8.0.1.1/pre-migrate.py
@@ -1,0 +1,7 @@
+# coding: utf-8
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """ DELETE FROM ir_translation
+            WHERE module = 'babycare_product_brand'; """)

--- a/babycare_product_brand/models/product.py
+++ b/babycare_product_brand/models/product.py
@@ -15,167 +15,167 @@ class ProductTemplate(models.Model):
         'custom.option',
         domain=[('option_type', '=', 'buggies.agecategory')],
         context={'default_option_type': 'buggies.agecategory'},
-        string="Age Category"
+        string="Age Category (Buggies)"
     )
     product_buggies_maxcarryweight_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'buggies.maxcarryweight')],
         context={'default_option_type': 'buggies.maxcarryweight'},
-        string="Maximum Carry Weight"
+        string="Maximum Carry Weight (Buggies)"
     )
     product_buggies_numberofwheels_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'buggies.numberofwheels')],
         context={'default_option_type': 'buggies.numberofwheels'},
-        string="Number of Wheels"
+        string="Number of Wheels (Buggies)"
     )
     product_carriers_directionofuse_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carriers.directionofuse')],
         context={'default_option_type': 'carriers.directionofuse'},
-        string="Direction of Use"
+        string="Direction of Use (Carriers)"
     )
     product_carriers_maxcarryweight_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carriers.maxcarryweight')],
         context={'default_option_type': 'carriers.maxcarryweight'},
-        string="Maximum Carry Weight"
+        string="Maximum Carry Weight (Carriers)"
     )
     product_carriers_type_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carriers.type')],
         context={'default_option_type': 'carriers.type'},
-        string="Type"
+        string="Type (Carriers)"
     )
     product_carseats_agecategory_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carseats.agecategory')],
         context={'default_option_type': 'carseats.agecategory'},
-        string="Age Category"
+        string="Age Category (Car Seats)"
     )
     product_carseats_childlength_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carseats.childlength')],
         context={'default_option_type': 'carseats.childlength'},
-        string="Child Length"
+        string="Child Length (Car Seats)"
     )
     product_carseats_childweight_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carseats.childweight')],
         context={'default_option_type': 'carseats.childweight'},
-        string="Child Weight"
+        string="Child Weight (Car Seats)"
     )
     product_carseats_directionofuse_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carseats.directionofuse')],
         context={'default_option_type': 'carseats.directionofuse'},
-        string="Direction of Use"
+        string="Direction of Use (Car Seats)"
     )
     product_carseats_installmethod_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'carseats.installmethod')],
         context={'default_option_type': 'carseats.installmethod'},
-        string="Install Method"
+        string="Install Method (Car Seats)"
     )
     product_clothes_season_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'clothes.season')],
         context={'default_option_type': 'clothes.season'},
-        string="Season"
+        string="Season (Clothes)"
     )
     product_clothes_size_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'clothes.size')],
         context={'default_option_type': 'clothes.size'},
-        string="Size"
+        string="Size (Clothes)"
     )
     product_highchairs_agecategory_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'highchairs.agecategory')],
         context={'default_option_type': 'highchairs.agecategory'},
-        string="Age Category"
+        string="Age Category (High Chairs)"
     )
     product_highchairs_material_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'highchairs.material')],
         context={'default_option_type': 'highchairs.material'},
-        string="Material"
+        string="Material (High Chairs)"
     )
     product_monitors_maxrange_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'monitors.maxrange')],
         context={'default_option_type': 'monitors.maxrange'},
-        string="Maximum Range"
+        string="Maximum Range (Monitors)"
     )
     product_rockers_maxcarryweight_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'rockers.maxcarryweight')],
         context={'default_option_type': 'rockers.maxcarryweight'},
-        string="Maximum Carry Weight"
+        string="Maximum Carry Weight (Rockers)"
     )
     product_strollers_numberofwheels_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'strollers.numberofwheels')],
         context={'default_option_type': 'strollers.numberofwheels'},
-        string="Number of Wheels"
+        string="Number of Wheels (Strollers)"
     )
     product_textiles_size_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'textiles.size')],
         context={'default_option_type': 'textiles.size'},
-        string="Size"
+        string="Size (Textiles)"
     )
     product_toys_agecategory_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'toys.agecategory')],
         context={'default_option_type': 'toys.agecategory'},
-        string="Age Category"
+        string="Age Category (Toys)"
     )
     product_toys_type_id = fields.Many2one(
         'custom.option',
         domain=[('option_type', '=', 'toys.type')],
         context={'default_option_type': 'toys.type'},
-        string="Type"
+        string="Type (Toys)"
     )
     product_buggies_adjustablebackrest = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Adjustable Backrest?"
+        string="Adjustable Backrest? (Buggies)"
     )
     product_clothes_gender = fields.Selection(
         [('boy', 'Boy'), ('girl', 'Girl'), ('unisex', 'Unisex')],
-        string="Gender"
+        string="Gender (Clothes)"
     )
     product_highchairs_includingdinnertray = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Including Dinner Tray"
+        string="Including Dinner Tray (High Chairs)"
     )
     product_highchairs_collapsible = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Collapsible"
+        string="Collapsible (High Chairs)"
     )
     product_monitors_includingcamera = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Including Camera"
+        string="Including Camera (Monitors)"
     )
     product_monitors_includingrecallfunction = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="2-way voice operation"
+        string="2-way voice operation (Monitors)"
     )
     product_rockers_collapsible = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Collapsible"
+        string="Collapsible (Rockers)"
     )
     product_travelcots_collapsible = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Collapsible"
+        string="Collapsible (Travelcots)"
     )
     product_travelcots_includingwheels = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Including Wheels"
+        string="Including Wheels (Travelcots)"
     )
     product_travelcots_includingcreephatch = fields.Selection(
         [('yes', 'Yes'), ('no', 'No')],
-        string="Including Creep Hatch"
+        string="Including Creep Hatch (Travelcots)"
     )
 
 

--- a/babycare_product_brand/views/product.xml
+++ b/babycare_product_brand/views/product.xml
@@ -101,73 +101,73 @@
 						</group>
 						<group name="am_strollers">
 							<label string="Strollers" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_strollers_numberofwheels_id" placeholder="Number of Wheels" options="{'no_create': True}" />
+							<field name="product_strollers_numberofwheels_id" placeholder="Number of Wheels" options="{'no_create': True}" string="Number of Wheels" />
 						</group>
 						<group name="am_carseats">
 							<label string="Car Seats" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_carseats_childweight_id" placeholder="Child Weight" options="{'no_create': True}" />
-							<field name="product_carseats_childlength_id" placeholder="Child Length" options="{'no_create': True}" />
-							<field name="product_carseats_agecategory_id" placeholder="Age Category" options="{'no_create': True}" />
-							<field name="product_carseats_directionofuse_id" placeholder="Direction of Use" options="{'no_create': True}" />
-							<field name="product_carseats_installmethod_id" placeholder="Install Method" options="{'no_create': True}" />
+							<field name="product_carseats_childweight_id" placeholder="Child Weight" options="{'no_create': True}" string="Child Weight" />
+							<field name="product_carseats_childlength_id" placeholder="Child Length" options="{'no_create': True}" string="Child Length" />
+							<field name="product_carseats_agecategory_id" placeholder="Age Category" options="{'no_create': True}" string="Age Category" />
+							<field name="product_carseats_directionofuse_id" placeholder="Direction of Use" options="{'no_create': True}" string="Direction of Use" />
+							<field name="product_carseats_installmethod_id" placeholder="Install Method" options="{'no_create': True}" string="Install Method" />
 						</group>
 					</group>
 					<group col="6">
 						<group name="am_buggies">
 							<label string="Buggies" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_buggies_adjustablebackrest" />
-							<field name="product_buggies_agecategory_id" placeholder="Age Category" options="{'no_create': True}" />
-							<field name="product_buggies_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" />
-							<field name="product_buggies_numberofwheels_id" placeholder="Number of Wheels" options="{'no_create': True}" />
+							<field name="product_buggies_adjustablebackrest" string="Adjustable Backrest" />
+							<field name="product_buggies_agecategory_id" placeholder="Age Category" options="{'no_create': True}" string="Age Category" />
+							<field name="product_buggies_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" string="Maximum Carry Weight" />
+							<field name="product_buggies_numberofwheels_id" placeholder="Number of Wheels" options="{'no_create': True}" string="Number of Wheels" />
 						</group>
 						<group name="am_highchairs">
 							<label string="High Chairs" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_highchairs_agecategory_id" placeholder="Age Category" options="{'no_create': True}" />
-							<field name="product_highchairs_material_id" placeholder="Material" options="{'no_create': True}" />
-							<field name="product_highchairs_includingdinnertray" />
-							<field name="product_highchairs_collapsible" />
+							<field name="product_highchairs_agecategory_id" placeholder="Age Category" options="{'no_create': True}" string="Age Category" />
+							<field name="product_highchairs_material_id" placeholder="Material" options="{'no_create': True}" string="Material" />
+							<field name="product_highchairs_includingdinnertray" string="Including Dinner Tray" />
+							<field name="product_highchairs_collapsible" string="Collapsible" />
 						</group>
 						<group name="am_carriers">
 							<label string="Carriers" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_carriers_type_id" placeholder="Type" options="{'no_create': True}" />
-							<field name="product_carriers_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" />
-							<field name="product_carriers_directionofuse_id" placeholder="Direction of Use" options="{'no_create': True}" />
+							<field name="product_carriers_type_id" placeholder="Type" options="{'no_create': True}" string="Type" />
+							<field name="product_carriers_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" string="Maximum Carry Weight" />
+							<field name="product_carriers_directionofuse_id" placeholder="Direction of Use" options="{'no_create': True}" string="Direction of Use" />
 						</group>
 					</group>
 					<group col="6">
 						<group name="am_textiles">
 							<label string="Textiles" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_textiles_size_id" placeholder="Size" options="{'no_create': True}" />
+							<field name="product_textiles_size_id" placeholder="Size" options="{'no_create': True}" string="Size" />
 						</group>
 						<group name="am_monitors">
 							<label string="Monitors" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_monitors_maxrange_id" placeholder="Maximum Range" options="{'no_create': True}" />
-							<field name="product_monitors_includingcamera" />
-							<field name="product_monitors_includingrecallfunction" />
+							<field name="product_monitors_maxrange_id" placeholder="Maximum Range" options="{'no_create': True}" string="Maximum Range" />
+							<field name="product_monitors_includingcamera" string="Including Camera" />
+							<field name="product_monitors_includingrecallfunction" string="2-way voice operation" />
 						</group>
 						<group name="am_clothes">
 							<label string="Clothes" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_clothes_size_id" placeholder="Size" options="{'no_create': True}" />
-							<field name="product_clothes_season_id" placeholder="Season" options="{'no_create': True}" />
-							<field name="product_clothes_gender" />
+							<field name="product_clothes_size_id" placeholder="Size" options="{'no_create': True}" string="Size" />
+							<field name="product_clothes_season_id" placeholder="Season" options="{'no_create': True}" string="Season" />
+							<field name="product_clothes_gender" string="Gender" />
 						</group>
 					</group>
 					<group col="6">
 						<group name="am_toys">
 							<label string="Toys" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_toys_type_id" placeholder="Type" options="{'no_create': True}" />
-							<field name="product_toys_agecategory_id" placeholder="Age Category" options="{'no_create': True}" />
+							<field name="product_toys_type_id" placeholder="Type" options="{'no_create': True}" string="Type" />
+							<field name="product_toys_agecategory_id" placeholder="Age Category" options="{'no_create': True}" string="Age Category" />
 						</group>
 						<group name="am_rockers">
 							<label string="Rockers" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_rockers_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" />
-							<field name="product_rockers_collapsible" />
+							<field name="product_rockers_maxcarryweight_id" placeholder="Maximum Carry Weight" options="{'no_create': True}" string="Maximum Carry Weight" />
+							<field name="product_rockers_collapsible" string="Collapsible" />
 						</group>
 						<group name="am_travelcots">
 							<label string="Travelcots" style="color: #f68519; font-size: 15px; font-weight: bold;" colspan="2" />
-							<field name="product_travelcots_collapsible" />
-							<field name="product_travelcots_includingwheels" />
-							<field name="product_travelcots_includingcreephatch" />
+							<field name="product_travelcots_collapsible" string="Collapsible" />
+							<field name="product_travelcots_includingwheels" string="Including Wheels" />
+							<field name="product_travelcots_includingcreephatch" string="Including Creep Hatch" />
 						</group>
 					</group>
                 </xpath>


### PR DESCRIPTION
Each field in the product attribute manager is made unique.

**Question**
The purpose of this change is to have unique names in the advanced search of the product variant model. (E.g.: in case we would like to mass-edit a field we need to know to which product group this field belongs to.) Disadvantage of this change is that also the names of the fields on the product form are changed.
Is there a way to have different names for the fields in the product form and the advanced search filtering? (E.g.: for the field product_buggies_agecategory_id we would like to have "Age Category (Buggies)" displayed in the advanced filtering but "Age Category" on the product form.)

New translations has been added. For this I created a new nl.po file and replaced this file with the old file in the i18n-folder. Is this the correct way to update translations?