### PR TITLE
[FIX] #3414, write stock_need_sync is True on magento.product mapping if x_availability is changed

### DIFF
--- a/bbc_sale/models/mrp_bom.py
+++ b/bbc_sale/models/mrp_bom.py
@@ -19,6 +19,8 @@ class MrpBom(models.Model):
             all_variants += variants
             for variant in variants:
                 avail = []
+                mage_product_mapping = self.env['magento.product'].search([
+                    ('oe_product_id', 'in', variant.ids)])
                 for line in bom.bom_line_ids:
                     if (line.attribute_value_ids <=
                             variant.attribute_value_ids):
@@ -33,6 +35,7 @@ class MrpBom(models.Model):
                         variant.default_code or variant.name,
                         variant.x_availability, x_availability)
                     variant.write({'x_availability': x_availability})
+                    mage_product_mapping.write({'stock_need_sync': True})
 
         return all_variants
 

--- a/bbc_sale/models/product.py
+++ b/bbc_sale/models/product.py
@@ -327,6 +327,9 @@ class Product(models.Model):
             if (product.x_availability != x_availability or
                     product.x_availability is False):
                 product.write({'x_availability': x_availability})
+            mage_product_mapping = self.env['magento.product'].search([
+                ('oe_product_id', 'in', self.ids)])
+            mage_product_mapping.write({'stock_need_sync': True})
 
         boms = self.env['mrp.bom'].search([
             ('bom_line_ids.product_id', 'in', self.ids),


### PR DESCRIPTION
The moment x_availability is changed on the product variant the newly introduced boolean stock_need_sync in the Magento product mapping becomes true.
This gives us the opportunity to only loop to the product variants with stock_need_sync = True for stock updates to Magento.