### PR TITLE
[FIX] #3458, max_incoming_stock_date: show date + lead time supplier if product is in stock

### DIFF
--- a/bbc_stock/README.rst
+++ b/bbc_stock/README.rst
@@ -30,7 +30,7 @@ TODO: unscanned products stay on top even if there are red and yellow lines.
 
 Other functionality
 ===================
-* Add a field to the product form that displays the maximum delivery date for all of the incoming stock. A manual override can be entered. This override will be reset when the override date is reached, or when there is actually stock incoming.
+* Add a field to the product form that displays the maximum delivery date for all of the incoming stock. A manual override can be entered. This override will be reset when the override date is reached, or when there is actually stock incoming. If a product is in stock the maximum delivery date is always the date_today + lead time supplier. On this way we always have a maximum delivery date greater than date_today on the Magento website front-end.
 * Menu shortcuts to late deliveries to and from customers or from suppliers. This changes the cutoff time of the 'late' filter on pickings to start of the day (in UTC).
 * Hide the stock locations group on the product form
 * Hide the lot tracking group on the product form

--- a/bbc_stock/models/product.py
+++ b/bbc_stock/models/product.py
@@ -44,8 +44,6 @@ class Product(models.Model):
                 order='date_expected desc', limit=1).mapped(
                     'date_expected')
             base_date = dates_expected[0] if dates_expected else today
-            if product.virtual_available > 0:
-                return base_date
             delay = product.seller_ids[0].delay if product.seller_ids else 0
             return fields.Date.to_string(
                 fields.Date.from_string(base_date) + timedelta(delay or 0))

--- a/bbc_stock/tests/test_max_incoming_stock_date.py
+++ b/bbc_stock/tests/test_max_incoming_stock_date.py
@@ -59,20 +59,14 @@ class TestMaxDate(TestStockCommon):
             'date_expected': next_year_feb,
         })
         picking_in.action_confirm()
-        next_year_feb_plus_delay = Date.to_string(
-            Date.from_string(next_year_feb) + timedelta(days=self.seller_delay)
-        )
+        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb)
         self.assertEqual(
-            self.product.max_incoming_stock_date, next_year_feb_plus_delay)
-        self.assertEqual(
-            self.bom_product.max_incoming_stock_date, next_year_feb_plus_delay)
-
+            self.bom_product.max_incoming_stock_date, next_year_feb)
         self.product.max_incoming_stock_date_override = True
         self.product.max_incoming_stock_date_override_value = self.today
         self.assertEqual(self.product.max_incoming_stock_date, self.today)
         self.env['product.product'].reset_max_incoming_date_override()
-        self.assertEqual(
-            self.product.max_incoming_stock_date, next_year_feb_plus_delay)
+        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb)
 
         # When a product has to be ordered, add supplier lead time to max date
         # expected of running orders
@@ -91,7 +85,7 @@ class TestMaxDate(TestStockCommon):
         })
         picking_out.action_confirm()
         self.product.refresh()
-        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb6)
+        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb)
 
         # Test that we can modify the picking's max_date (#2800)
         # Call _register_hook manually because tests run before Odoo does

--- a/bbc_stock/tests/test_max_incoming_stock_date.py
+++ b/bbc_stock/tests/test_max_incoming_stock_date.py
@@ -59,15 +59,20 @@ class TestMaxDate(TestStockCommon):
             'date_expected': next_year_feb,
         })
         picking_in.action_confirm()
-        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb)
+        next_year_feb_plus_delay = Date.to_string(
+            Date.from_string(next_year_feb) + timedelta(days=self.seller_delay)
+        )
         self.assertEqual(
-            self.bom_product.max_incoming_stock_date, next_year_feb)
+            self.product.max_incoming_stock_date, next_year_feb_plus_delay)
+        self.assertEqual(
+            self.bom_product.max_incoming_stock_date, next_year_feb_plus_delay)
 
         self.product.max_incoming_stock_date_override = True
         self.product.max_incoming_stock_date_override_value = self.today
         self.assertEqual(self.product.max_incoming_stock_date, self.today)
         self.env['product.product'].reset_max_incoming_date_override()
-        self.assertEqual(self.product.max_incoming_stock_date, next_year_feb)
+        self.assertEqual(
+            self.product.max_incoming_stock_date, next_year_feb_plus_delay)
 
         # When a product has to be ordered, add supplier lead time to max date
         # expected of running orders

--- a/bbc_stock/tests/test_max_incoming_stock_date.py
+++ b/bbc_stock/tests/test_max_incoming_stock_date.py
@@ -93,3 +93,43 @@ class TestMaxDate(TestStockCommon):
         picking_out.write({'max_date': next_year_feb6})
         self.assertEqual(move.date_expected, next_year_feb6 + ' 00:00:00')
         self.assertEqual(picking_out.max_date, next_year_feb6 + ' 00:00:00')
+
+    def test_02_max_date(self):
+        next_year_apr = '%s-04-01' % (int(self.today[:4]) + 1)
+        delay = Date.to_string(
+            Date.from_string(self.today) + timedelta(days=self.seller_delay))
+
+        """ Test if max_incoming_stock_date is the date today plus delay
+        in case there is no stock of the product. """
+        self.assertEqual(self.product.max_incoming_stock_date, delay)
+        self.assertEqual(self.bom_product.max_incoming_stock_date, delay)
+
+        picking_in = self.PickingObj.create({
+            'partner_id': self.partner_delta_id,
+            'picking_type_id': self.picking_type_in})
+        self.MoveObj.create({
+            'name': self.product.name,
+            'product_id': self.product.id,
+            'product_uom_qty': 1,
+            'product_uom': self.product.uom_id.id,
+            'picking_id': picking_in.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'date_expected': next_year_apr,
+        })
+
+        """ Test if date_expected is the max_incoming_stock_date
+        in case there are incoming products. """
+        picking_in.action_confirm()
+        self.product.refresh()
+        self.assertEqual(self.product.max_incoming_stock_date, next_year_apr)
+        self.assertEqual(
+            self.bom_product.max_incoming_stock_date, next_year_apr)
+
+        """ Test if the max_incoming_stock_date is the date today plus
+        delay in case there is stock of the product. """
+        picking_in.action_done()
+        self.product.refresh()
+        self.assertEqual(self.product.max_incoming_stock_date, delay)
+        self.assertEqual(
+            self.bom_product.max_incoming_stock_date, delay)


### PR DESCRIPTION
This PR fixes two possible scenarios.

1. The max_incoming_stock_date of our products updates only one time per day at night. The stock levels are updated to Magento each 4 hours.
This means that in the current set-up it is possible that a product runs out of stock during the day but at the same time it shows a back in stock date (coming from max_incoming_stock_date) of the same day.
This fix shows the date_today + lead time supplier in case a product is in stock so the visible date in Magento is always greater than the date_today.

2. Imagine: product A is one time in stock but this product is needed twice in a variant of a configurable product. Because the product is in stock one time it shows the date_today in the current set-up for the variant of the configurable product.
This fix shows the date_today + lead time supplier in case a product is in stock so the visible date for a not-in-stock variant of a config product (example above) in Magento is always greater than the date_today.