### PR TITLE
[FIX] #3457, automated email outgoing delivery working from Barcode Scanning Interface as well

### DIFF
--- a/bbc_sale/models/stock_picking.py
+++ b/bbc_sale/models/stock_picking.py
@@ -1,4 +1,8 @@
+# coding: utf-8
+import logging
 from openerp import models, fields, api
+
+_logger = logging.getLogger(__name__)
 
 
 class Picking(models.Model):
@@ -38,6 +42,5 @@ class Picking(models.Model):
         res = super(Picking, self).do_transfer()
         server_action_id = self.env.ref(
             'bbc_sale.action_send_email_delivery_shipped_magento').id
-        self.env['ir.actions.server'].browse(
-            server_action_id).run()
+        self.env['ir.actions.server'].browse(server_action_id)
         return res

--- a/bbc_sale/models/stock_picking.py
+++ b/bbc_sale/models/stock_picking.py
@@ -49,8 +49,9 @@ class Picking(models.Model):
         Mail trigger only applies if the destination usage is a customer
         and if there are related sale orders to the picking. """
         res = super(Picking, self).do_transfer()
-        if (self.location_dest_id.usage == 'customer' and
-                (self.group_id and self.env['sale.order'].search([
-                    ('procurement_group_id', '=', self.group_id.id)]))):
-            self.send_mail_outgoing_delivery()
+        for picking in self:
+            if (picking.location_dest_id.usage == 'customer' and
+                    (picking.group_id and self.env['sale.order'].search([
+                        ('procurement_group_id', '=', picking.group_id.id)]))):
+                picking.send_mail_outgoing_delivery()
         return res

--- a/bbc_sale/models/stock_picking.py
+++ b/bbc_sale/models/stock_picking.py
@@ -44,7 +44,11 @@ class Picking(models.Model):
     @api.multi
     def do_transfer(self):
         """ Trigger send_mail_outgoing_delivery on transfer of outgoing
-        delivery to automatically send an email to the customer. """
+        delivery to automatically send an email to the customer.
+        Mail trigger only applies to outgoing deliveries of the central
+        warehouse where the location destination is a customer. """
         res = super(Picking, self).do_transfer()
-        self.send_mail_outgoing_delivery()
+        if (self.picking_type_id.id == 7 and
+                self.location_dest_id.usage == 'customer'):
+            self.send_mail_outgoing_delivery()
         return res

--- a/bbc_sale/models/stock_picking.py
+++ b/bbc_sale/models/stock_picking.py
@@ -1,8 +1,5 @@
 # coding: utf-8
-import logging
 from openerp import models, fields, api
-
-_logger = logging.getLogger(__name__)
 
 
 class Picking(models.Model):
@@ -36,11 +33,20 @@ class Picking(models.Model):
             [sale.remarks for sale in sales])
 
     @api.multi
+    def send_mail_outgoing_delivery(self):
+        """ Runs the server action of sending an email with the template
+        Magento | Send Email After Outgoing Delivery Is Shipped.
+        active_ids included in context because the server action has to
+        work in the Barcode Scanning Interface as well. """
+        template = self.env.ref(
+            'bbc_sale.action_send_email_delivery_shipped_magento')
+        self.env['ir.actions.server'].browse(template.id).with_context(
+            active_ids=self.ids).run()
+
+    @api.multi
     def do_transfer(self):
-        """ Trigger server action 'action_send_email_delivery_shipped_magento'
-        on transfer of outgoing delivery """
+        """ Trigger send_mail_outgoing_delivery on transfer of outgoing
+        delivery to automatically send an email to the customer. """
         res = super(Picking, self).do_transfer()
-        server_action_id = self.env.ref(
-            'bbc_sale.action_send_email_delivery_shipped_magento').id
-        self.env['ir.actions.server'].browse(server_action_id)
+        self.send_mail_outgoing_delivery()
         return res

--- a/bbc_sale/models/stock_picking.py
+++ b/bbc_sale/models/stock_picking.py
@@ -38,10 +38,8 @@ class Picking(models.Model):
         Magento | Send Email After Outgoing Delivery Is Shipped.
         active_ids included in context because the server action has to
         work in the Barcode Scanning Interface as well. """
-        template = self.env.ref(
-            'bbc_sale.action_send_email_delivery_shipped_magento')
-        self.env['ir.actions.server'].browse(template.id).with_context(
-            active_ids=self.ids).run()
+        action = self.env.ref('bbc_sale.action_send_email_delivery_shipped_magento')
+        action.with_context(active_ids=self.ids).run()
 
     @api.multi
     def do_transfer(self):


### PR DESCRIPTION
active_ids included in context of method 'send_mail_outgoing_delivery' because the server action has to work as well when an outgoing delivery is transferred from the Barcode Scanning Interface.