### PR TITLE
#3525, [FIX] variant_published to False if x_availability < 1 (incl. negative x_availability)

### DIFF
--- a/bbc_sale/__openerp__.py
+++ b/bbc_sale/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Babycare Sales customizations",
     "category": "Sale",
-    "version": "8.0.2.2",
+    "version": "8.0.2.3",
     "author": "Opener B.V.",
     "website": 'https://opener.am',
     "depends": [

--- a/bbc_sale/migrations/8.0.2.3/post-migrate.py
+++ b/bbc_sale/migrations/8.0.2.3/post-migrate.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """ Set variants with x_availabilty less than 1 (e.g. 0
+    or below 0) to variant_published = false. """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['product.product'].search([
+        ('x_availability', '<', 1),
+        ('variant_eol', '=', True),
+        ('variant_published', '=', True)
+    ]).write({'variant_published': False})

--- a/bbc_sale/models/product.py
+++ b/bbc_sale/models/product.py
@@ -338,7 +338,7 @@ class Product(models.Model):
 
         to_unpublish = self.env['product.product'].search([
             ('id', 'in', affected.ids),
-            ('x_availability', '=', 0),
+            ('x_availability', '<', 1),
             ('variant_eol', '=', True),
             ('variant_published', '=', True),
         ])


### PR DESCRIPTION
**ISSUE**
x_availability in search is defined as '=' 0. It is possible though that a variant has a x_availability of less than 0. (E.g.: the product is sold twice in the same time frame.)

**FIX**
Change ('x_availability', '=', 0) to ('x_availability', '<', 1) so variants with a negative x_availability are also included in the search.
The post-migrate script makes sure that existing variants with a negative x_availability (< 1) and a variant_eol = true and variant_published = true are become variant_published = false.

**NOTE**
The test test_variant_eol.py fails with this new code but this was also the case with the previous code. It fails on line 83 of test_variant_eol.py -> self.assertFalse(self.bom_product.variant_published). Do you have an idea how this can be fixed?