### PR TITLE
[FIX] #3610, make attributes for size (clothes and textiles) unique for each variant

### DIFF
--- a/babycare_product_brand/models/product.py
+++ b/babycare_product_brand/models/product.py
@@ -194,6 +194,18 @@ class ProductProduct(models.Model):
         context={'default_option_type': 'color'},
         string="Color"
     )
+    product_clothes_size_id = fields.Many2one(
+        'custom.option',
+        domain=[('option_type', '=', 'clothes.size')],
+        context={'default_option_type': 'clothes.size'},
+        string="Size (Clothes)"
+    )
+    product_textiles_size_id = fields.Many2one(
+        'custom.option',
+        domain=[('option_type', '=', 'textiles.size')],
+        context={'default_option_type': 'textiles.size'},
+        string="Size (Textiles)"
+    )
 
     @api.multi
     def open_attribute_manager(self):


### PR DESCRIPTION
This commit makes product_clothes_size_id and product_textiles_size_id available on product.product. This makes it possible that each variant of a configurable product can have a unique custom option. (Like product_color_id).