### PR TITLE
[FIX] #3756, deactivate product template once variant is EndOfLife

### DIFF
--- a/bbc_sale/__openerp__.py
+++ b/bbc_sale/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Babycare Sales customizations",
     "category": "Sale",
-    "version": "8.0.2.3",
+    "version": "8.0.2.4",
     "author": "Opener B.V.",
     "website": 'https://opener.am',
     "depends": [

--- a/bbc_sale/migrations/8.0.2.4/post-migrate.py
+++ b/bbc_sale/migrations/8.0.2.4/post-migrate.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """ Set templates inactive if the variants belong to the
+    template are inactive as well. """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    products = env['product.product'].search([
+        ('active', '=', False),
+        ('variant_eol', '=', True),
+        ('bom_ids', '=', False)
+    ])
+    for product in products:
+        template = product.mapped('product_tmpl_id')
+        for temp in template:
+            temp.write({'active': False})

--- a/bbc_sale/migrations/8.0.2.4/post-migrate.py
+++ b/bbc_sale/migrations/8.0.2.4/post-migrate.py
@@ -9,9 +9,14 @@ def migrate(cr, version):
         return
     env = api.Environment(cr, SUPERUSER_ID, {})
     products = env['product.product'].search([
+        '&',
         ('active', '=', False),
         ('variant_eol', '=', True),
-        ('bom_ids', '=', False)
+        '|',
+        ('bom_ids', '=', False),
+        '&',
+        ('bom_ids', '!=', False),
+        ('prod_type', '=', 'simple')
     ])
     for product in products:
         template = product.mapped('product_tmpl_id')

--- a/bbc_sale/migrations/8.0.2.4/post-migrate.py
+++ b/bbc_sale/migrations/8.0.2.4/post-migrate.py
@@ -16,4 +16,5 @@ def migrate(cr, version):
     for product in products:
         template = product.mapped('product_tmpl_id')
         for temp in template:
+            temp.write({'website_published': False})
             temp.write({'active': False})

--- a/bbc_sale/models/product.py
+++ b/bbc_sale/models/product.py
@@ -163,6 +163,7 @@ class ProductTemplate(models.Model):
         will be set to inactive. To be called from cron.
         The inactivate status will be set to the product template so the
         variant will automatically be inactive as well.
+        Also works on products with a BoM but with only one variant.
 
         Legacy note: works on product products even if defined on
         product.template.
@@ -171,10 +172,15 @@ class ProductTemplate(models.Model):
             datetime.now() - relativedelta(months=3))
         start_time = time.time()
         products = self.env['product.product'].search([
+            '&',
             ('variant_eol', '=', True),
             ('write_date', '<', cutoff_datetime),
             ('qty_available', '=', 0),
-            ('bom_ids', '=', False)])
+            '|',
+            ('bom_ids', '=', False),
+            '&',
+            ('bom_ids', '!=', False),
+            ('prod_type', '=', 'simple')])
         logger.debug(
             'Found %s candidate products in %s seconds to set inactive',
             len(products), time.time() - start_time)

--- a/bbc_sale/models/product.py
+++ b/bbc_sale/models/product.py
@@ -161,6 +161,8 @@ class ProductTemplate(models.Model):
         """ Products that have been set to EOL at least three months ago,
         have no physical stock and and that have no recent stock moves
         will be set to inactive. To be called from cron.
+        The inactivate status will be set to the product template so the
+        variant will automatically be inactive as well.
 
         Legacy note: works on product products even if defined on
         product.template.
@@ -183,9 +185,11 @@ class ProductTemplate(models.Model):
                 logger.debug(
                     'Product %s has recent stock moves', product.id)
                 continue
-            logger.info(
-                'Setting product %s to inactive', product.id)
-            product.write({'active': False})
+            template = product.mapped('product_tmpl_id')
+            for temp in template:
+                logger.info(
+                    'Setting product template %s to inactive', temp.id)
+                temp.write({'active': False})
 
     def _register_hook(self, cr):
         """ Remove draft state """

--- a/bbc_sale/tests/test_variant_eol.py
+++ b/bbc_sale/tests/test_variant_eol.py
@@ -133,3 +133,19 @@ class TestVariantEOL(TransactionCase):
         self.bom_product.product_tmpl_id.write({'website_published': True})
         self.assertFalse(self.bom_product.variant_published)
         self.assertTrue(pr2.variant_published)
+
+    def test_06_product_template_eol_inactive(self):
+        """ While running deactivate_obsolete_products set the simple product
+        template to inactive so the product variant is set to inactive as well """
+        self.assertTrue(self.product.active)
+        self.assertTrue(self.product.product_tmpl_id.active)
+        self.product.write({'state': 'end'})
+        self.assertTrue(self.product.variant_eol)
+
+        self.env.cr.execute(
+            """ UPDATE product_product
+            SET write_date = '2017-01-01'
+            """)
+        self.env['product.template'].deactivate_obsolete_products()
+        self.assertFalse(self.product.product_tmpl_id.active)
+        self.assertFalse(self.product.active)

--- a/bbc_sale/tests/test_variant_eol.py
+++ b/bbc_sale/tests/test_variant_eol.py
@@ -149,3 +149,20 @@ class TestVariantEOL(TransactionCase):
         self.env['product.template'].deactivate_obsolete_products()
         self.assertFalse(self.product.product_tmpl_id.active)
         self.assertFalse(self.product.active)
+
+    def test_07_product_template_bom_one_variant_eol_inactive(self):
+        """ While running deactivate_obsolete_products set the variant of a product template with
+        a bom with only one variant to inactive so the product variant is set to inactive as well """
+        self.assertTrue(self.bom_product.active)
+        self.assertTrue(self.component.active)
+        self.bom_product.write({'prod_type': 'simple'})
+        self.component.write({'variant_eol': True})
+        self.assertTrue(self.bom_product.variant_eol)
+
+        self.env.cr.execute(
+            """ UPDATE product_product
+            SET write_date = '2017-01-01'
+            """)
+        self.env['product.template'].deactivate_obsolete_products()
+        self.assertFalse(self.component.active)
+        self.assertFalse(self.bom_product.active)


### PR DESCRIPTION
Current behavior: once a product variant is EndOfLife only the variant is set to inactive but the product template remains active.

This pull request will change the behavior for once a product variant is EndOfLife. As soon as the product variant is EOL, the template of the variant is set to inactive and so the product variant will automatically be inactive.

A migration script is included for current active EOL product templates with inactive variants. Script will look for all inactive product variants where variant_eol is true and where there is BOM attached (so only for simple products) and set the template of these variants to inactive.