### PR TITLE
[IMP] #3684, group show cost price on sales order lines added and field in sales order view changed to only show if user is in group

### DIFF
--- a/bbc_sale/__openerp__.py
+++ b/bbc_sale/__openerp__.py
@@ -17,6 +17,7 @@
         'magento_bridge',  # Override of product view
     ],
     'data': [
+        'security/sale_security.xml',
         'data/account_fiscal_position.xml',
         'views/account_invoice.xml',
         'views/pos_order.xml',

--- a/bbc_sale/i18n_extra/nl.po
+++ b/bbc_sale/i18n_extra/nl.po
@@ -25,3 +25,7 @@ msgstr "Opmerkingen"
 msgid "Can be ordered"
 msgstr "Bestelbaar"
 
+#. module: bbc_sale
+#: model:res.groups,name:bbc_sale.group_show_cost_price_on_sales_order
+msgid "Show cost price on Sales order lines"
+msgstr "Kostprijs weergeven op verkooporderregels"

--- a/bbc_sale/security/sale_security.xml
+++ b/bbc_sale/security/sale_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="group_show_cost_price_on_sales_order" model="res.groups">
+            <field name="name">Show cost price on Sales order lines</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+    </data>
+</openerp>

--- a/bbc_sale/views/sale_order.xml
+++ b/bbc_sale/views/sale_order.xml
@@ -19,6 +19,9 @@
                     <attribute name="colors" translation="off">red:virtual_available&lt;0;blue:virtual_available&gt;=0 and product_state in ('draft', 'end', 'obsolete');black:virtual_available&gt;=0 and product_state not in ('draft', 'end', 'obsolete')</attribute>
 report/stock_graph.py:from openerp.report.misc import choice_colors
                 </xpath>
+                <xpath expr="//page/field[@name='order_line']/tree/field[@name='purchase_price']" position="attributes">
+                    <attribute name="groups">bbc_sale.group_show_cost_price_on_sales_order</attribute>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
New security record added which add a checkbox on the user to yes or no show cost price on sales order lines. The field cost price in the sales order view is changed and will only be visible if the user is in the group (so when the checkbox is ticked).